### PR TITLE
Update cmd-key.ts

### DIFF
--- a/src/cmd-key.ts
+++ b/src/cmd-key.ts
@@ -48,7 +48,7 @@ async function genKey() {
   const pair = await subtle.generateKey({
     name: 'ECDSA',
     namedCurve: 'P-256'
-  }, true, [])
+  }, true, ['sign', 'verify'])
 
   const publicKeyBuf = await subtle.exportKey('spki', pair.publicKey as CryptoKey)
   const privateKeyBuf = await subtle.exportKey('pkcs8', pair.privateKey as CryptoKey)


### PR DESCRIPTION
根据 Web Crypto API 的规范，ECDSA 应该指定一个或多个用途。不指定会导致高版本的node.js运行时出错。